### PR TITLE
Automatic `flake.lock` update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1691492522,
-        "narHash": "sha256-LHe9QGeo5HYBPXuTvW26wyTAwWf/o3I9hpIZpAAx8gY=",
+        "lastModified": 1691921730,
+        "narHash": "sha256-2vTR0Vq2VRQt7+4todEdOJRGIU/qyPdVCXJgbosz3Aw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "8fec2d96e94b620d62ee5dbf52bd757c2c45ec9f",
+        "rev": "9279ce7180483c5ec9e6da74b87000a49a4942c0",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     "indent-bars": {
       "flake": false,
       "locked": {
-        "lastModified": 1691445921,
-        "narHash": "sha256-2kiZLyCNXT4zoQeiW5wl4942q9kpWg/Xjdl37BQegZ8=",
+        "lastModified": 1691609947,
+        "narHash": "sha256-hLIqwuWt75kEQqfzZ+VKQsSVhuHqFRzN8ko29Y/Pi/o=",
         "owner": "jdtsmith",
         "repo": "indent-bars",
-        "rev": "9935c0f9a28f07847582514707bc04dd5c228983",
+        "rev": "7da1a4a2a4d7e024a7eff99fde08844049287e04",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691368598,
-        "narHash": "sha256-ia7li22keBBbj02tEdqjVeLtc7ZlSBuhUk+7XTUFr14=",
+        "lastModified": 1691654369,
+        "narHash": "sha256-gSILTEx1jRaJjwZxRlnu3ZwMn1FVNk80qlwiCX8kmpo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a8e9243812ba528000995b294292d3b5e120947",
+        "rev": "ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1691421349,
-        "narHash": "sha256-RRJyX0CUrs4uW4gMhd/X4rcDG8PTgaaCQM5rXEJOx6g=",
+        "lastModified": 1691693223,
+        "narHash": "sha256-9t8ZY1XNAsWqxAJmXgg+GXqF5chORMVnBT6PSHaRV3I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "011567f35433879aae5024fc6ec53f2a0568a6c4",
+        "rev": "18784aac1013da9b442adf29b6c7c228518b5d3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Automatic update
## Inputs updated
```
Flake lock file updates:

• Updated input 'emacs-overlay':
    'github:nix-community/emacs-overlay/8fec2d96e94b620d62ee5dbf52bd757c2c45ec9f' (2023-08-08)
  → 'github:nix-community/emacs-overlay/9279ce7180483c5ec9e6da74b87000a49a4942c0' (2023-08-13)
• Updated input 'emacs-overlay/nixpkgs':
    'github:NixOS/nixpkgs/5a8e9243812ba528000995b294292d3b5e120947' (2023-08-07)
  → 'github:NixOS/nixpkgs/ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e' (2023-08-10)
• Updated input 'emacs-overlay/nixpkgs-stable':
    'github:NixOS/nixpkgs/011567f35433879aae5024fc6ec53f2a0568a6c4' (2023-08-07)
  → 'github:NixOS/nixpkgs/18784aac1013da9b442adf29b6c7c228518b5d3f' (2023-08-10)
• Updated input 'indent-bars':
    'github:jdtsmith/indent-bars/9935c0f9a28f07847582514707bc04dd5c228983' (2023-08-07)
  → 'github:jdtsmith/indent-bars/7da1a4a2a4d7e024a7eff99fde08844049287e04' (2023-08-09)
```
## Closures diff
```
0001-Fix-cross-compilation-by-looking-for-ar.patch: ε → ∅
Pygments: 2.14.0.tar.gz.drv → 2.15.1.tar.gz.drv
auditable-cargo: 1.70.0.drv → 1.71.1.drv
auditable-cargo-bootstrap: 1.69.0.drv → 1.70.0.drv
avoid-translation-fallout-from-lexgrog-fix.drv: ∅ → ε
builder.sh: -10.4 KiB
cargo: 1.70.0.drv → 1.71.1.drv
cargo-bootstrap: 1.69.0.drv → 1.70.0.drv
click: 8.1.3.tar.gz.drv → 8.1.6.tar.gz.drv
corfu-terminal: 0.6.tar.drv → 0.7.tar.drv
curl: 8.1.2.drv, 8.1.2.tar.bz2.drv → 8.2.1.drv, 8.2.1.tar.xz.drv
e2016928db1147a2a46de6ee9fa878ca0e9d8fc8.patch.drv: ε → ∅
emacs-consult: 20230806.1802.drv → 20230811.1232.drv
emacs-corfu-terminal: 0.6.drv → 0.7.drv
emacs-embark: 20230805.1458.drv → 20230808.1506.drv
emacs-envrc: 20230804.652.drv → 20230809.600.drv
emacs-nerd-icons: 20230807.42.drv → 20230812.1744.drv
emacs-sideline: 20230411.1926.drv → 20230808.2230.drv
emacs-transient: 20230723.1411.drv → 20230810.1716.drv
emacs-treemacs: 20230807.1952.drv → 20230809.2040.drv
filelock: 3.12.0.tar.gz.drv → 3.12.2.tar.gz.drv
fix-test-failures-when-iconv-not-available.drv: ∅ → ε
freetype: 2.13.0.drv, 2.13.0.tar.xz.drv → 2.13.1.drv, 2.13.1.tar.xz.drv
gcc: +9.4 KiB
gnutar: 1.34.drv → 1.35.drv
groff: 1.22.4.drv, 1.22.4.tar.gz.drv → 1.23.0.drv, 1.23.0.tar.gz.drv
hatchling: 1.13.0.tar.gz.drv → 1.18.0.tar.gz.drv
http-tiny-verify-ssl-by-default.patch: ε → ∅
improve-lexgrog-portability.drv: ∅ → ε
kbd: 2.5.1.drv, 2.5.1.tar.xz.drv → 2.6.1.drv, 2.6.1.tar.xz.drv
libgccjit: +9.4 KiB
libpfm: 4.12.0.drv, 4.12.0.tar.gz.drv → 4.13.0.drv, 4.13.0.tar.gz.drv
nghttp2: 1.51.0.drv, 1.51.0.tar.bz2.drv → 1.54.0.drv, 1.54.0.tar.bz2.drv
no-sys-dirs: 5.31.patch → 5.38.0.patch
node-v18.16.1.tar.xz.drv: ε → ∅
node-v18.17.1.tar.xz.drv: ∅ → ε
nodejs: 18.16.1.drv → 18.17.1.drv
nss: 3.90.tar.gz.drv → 3.92.tar.gz.drv
nss-cacert: 3.90.drv → 3.92.drv
nss-cacert-certdata: 3.90.drv → 3.92.drv
packaging: 23.0.tar.gz.drv → 23.1.tar.gz.drv
perl: 5.36.0.drv, 5.36.0.tar.gz.drv → 5.38.0.drv, 5.38.0.tar.gz.drv
perl5.36.0-Authen-SASL: 2.16.drv → ∅
perl5.36.0-CGI: 4.51.drv → ∅
perl5.36.0-CGI-Fast: 2.15.drv → ∅
perl5.36.0-CPAN-Meta-Check: 0.014.drv → ∅
perl5.36.0-Capture-Tiny: 0.48.drv → ∅
perl5.36.0-Class-Inspector: 1.36.drv → ∅
perl5.36.0-Digest-HMAC: 1.03.drv → ∅
perl5.36.0-Encode-Locale: 1.05.drv → ∅
perl5.36.0-ExtUtils-Config: 0.008.drv → ∅
perl5.36.0-ExtUtils-Helpers: 0.026.drv → ∅
perl5.36.0-ExtUtils-InstallPaths: 0.012.drv → ∅
perl5.36.0-FCGI: 0.79.drv → ∅
perl5.36.0-FCGI-ProcManager: 0.28.drv → ∅
perl5.36.0-File-Listing: 6.14.drv → ∅
perl5.36.0-File-ShareDir: 1.118.drv → ∅
perl5.36.0-File-ShareDir-Install: 0.13.drv → ∅
perl5.36.0-Font-TTF: 1.06.drv → ∅
perl5.36.0-HTML-Parser: 3.75.drv → ∅
perl5.36.0-HTML-TagCloud: 0.38.drv → ∅
perl5.36.0-HTML-Tagset: 3.20.drv → ∅
perl5.36.0-HTTP-Cookies: 6.09.drv → ∅
perl5.36.0-HTTP-Daemon: 6.14.drv → ∅
perl5.36.0-HTTP-Date: 6.05.drv → ∅
perl5.36.0-HTTP-Message: 6.26.drv → ∅
perl5.36.0-HTTP-Negotiate: 6.01.drv → ∅
perl5.36.0-IO-HTML: 1.004.drv → ∅
perl5.36.0-IO-Socket-SSL: 2.068.drv → ∅
perl5.36.0-IO-String: 1.08.drv → ∅
perl5.36.0-LWP-MediaTypes: 6.04.drv → ∅
perl5.36.0-Module-Build: 0.4231.drv → ∅
perl5.36.0-Module-Build-Tiny: 0.039.drv → ∅
perl5.36.0-Mozilla-CA: 20200520.drv → ∅
perl5.36.0-Net-HTTP: 6.19.drv → ∅
perl5.36.0-Net-SMTP-SSL: 1.04.drv → ∅
perl5.36.0-Net-SSLeay: 1.92.drv → ∅
perl5.36.0-Sub-Uplevel: 0.2800.drv → ∅
perl5.36.0-TermReadKey: 2.38.drv → ∅
perl5.36.0-Test-Deep: 1.130.drv → ∅
perl5.36.0-Test-Fatal: 0.016.drv → ∅
perl5.36.0-Test-Needs: 0.002006.drv → ∅
perl5.36.0-Test-NoWarnings: 1.04.drv → ∅
perl5.36.0-Test-RequiresInternet: 0.05.drv → ∅
perl5.36.0-Test-Warn: 0.36.drv → ∅
perl5.36.0-TimeDate: 2.33.drv → ∅
perl5.36.0-Try-Tiny: 0.30.drv → ∅
perl5.36.0-URI: 5.05.drv → ∅
perl5.36.0-WWW-RobotRules: 6.02.drv → ∅
perl5.36.0-XML-NamespaceSupport: 1.12.drv → ∅
perl5.36.0-XML-Parser: 2.46.drv → ∅
perl5.36.0-XML-SAX: 1.02.drv → ∅
perl5.36.0-XML-SAX-Base: 1.09.drv → ∅
perl5.36.0-gettext: 1.07.drv → ∅
perl5.36.0-libnet: 3.12.drv → ∅
perl5.36.0-libwww-perl: 6.67.drv → ∅
perl5.38.0-Authen-SASL: ∅ → 2.16.drv
perl5.38.0-CGI: ∅ → 4.51.drv
perl5.38.0-CGI-Fast: ∅ → 2.15.drv
perl5.38.0-CPAN-Meta-Check: ∅ → 0.014.drv
perl5.38.0-Capture-Tiny: ∅ → 0.48.drv
perl5.38.0-Class-Inspector: ∅ → 1.36.drv
perl5.38.0-Digest-HMAC: ∅ → 1.03.drv
perl5.38.0-Encode-Locale: ∅ → 1.05.drv
perl5.38.0-ExtUtils-Config: ∅ → 0.008.drv
perl5.38.0-ExtUtils-Helpers: ∅ → 0.026.drv
perl5.38.0-ExtUtils-InstallPaths: ∅ → 0.012.drv
perl5.38.0-FCGI: ∅ → 0.79.drv
perl5.38.0-FCGI-ProcManager: ∅ → 0.28.drv
perl5.38.0-File-Listing: ∅ → 6.14.drv
perl5.38.0-File-ShareDir: ∅ → 1.118.drv
perl5.38.0-File-ShareDir-Install: ∅ → 0.13.drv
perl5.38.0-Font-TTF: ∅ → 1.06.drv
perl5.38.0-HTML-Parser: ∅ → 3.75.drv
perl5.38.0-HTML-TagCloud: ∅ → 0.38.drv
perl5.38.0-HTML-Tagset: ∅ → 3.20.drv
perl5.38.0-HTTP-Cookies: ∅ → 6.09.drv
perl5.38.0-HTTP-Daemon: ∅ → 6.14.drv
perl5.38.0-HTTP-Date: ∅ → 6.05.drv
perl5.38.0-HTTP-Message: ∅ → 6.26.drv
perl5.38.0-HTTP-Negotiate: ∅ → 6.01.drv
perl5.38.0-IO-HTML: ∅ → 1.004.drv
perl5.38.0-IO-Socket-SSL: ∅ → 2.068.drv
perl5.38.0-IO-String: ∅ → 1.08.drv
perl5.38.0-LWP-MediaTypes: ∅ → 6.04.drv
perl5.38.0-Module-Build: ∅ → 0.4231.drv
perl5.38.0-Module-Build-Tiny: ∅ → 0.039.drv
perl5.38.0-Mozilla-CA: ∅ → 20200520.drv
perl5.38.0-Net-HTTP: ∅ → 6.19.drv
perl5.38.0-Net-SMTP-SSL: ∅ → 1.04.drv
perl5.38.0-Net-SSLeay: ∅ → 1.92.drv
perl5.38.0-Sub-Uplevel: ∅ → 0.2800.drv
perl5.38.0-TermReadKey: ∅ → 2.38.drv
perl5.38.0-Test-Deep: ∅ → 1.130.drv
perl5.38.0-Test-Fatal: ∅ → 0.016.drv
perl5.38.0-Test-Needs: ∅ → 0.002006.drv
perl5.38.0-Test-NoWarnings: ∅ → 1.04.drv
perl5.38.0-Test-RequiresInternet: ∅ → 0.05.drv
perl5.38.0-Test-Warn: ∅ → 0.36.drv
perl5.38.0-TimeDate: ∅ → 2.33.drv
perl5.38.0-Try-Tiny: ∅ → 0.30.drv
perl5.38.0-URI: ∅ → 5.05.drv
perl5.38.0-WWW-RobotRules: ∅ → 6.02.drv
perl5.38.0-XML-NamespaceSupport: ∅ → 1.12.drv
perl5.38.0-XML-Parser: ∅ → 2.46.drv
perl5.38.0-XML-SAX: ∅ → 1.02.drv
perl5.38.0-XML-SAX-Base: ∅ → 1.09.drv
perl5.38.0-gettext: ∅ → 1.07.drv
perl5.38.0-libnet: ∅ → 3.12.drv
perl5.38.0-libwww-perl: ∅ → 6.67.drv
pluggy: 1.0.0.tar.gz.drv → ∅
pytest: 7.2.1.tar.gz.drv → 7.4.0.tar.gz.drv
pytest-mock: 3.10.0.tar.gz.drv → 3.11.1.tar.gz.drv
pytest-xdist: 3.2.1.tar.gz.drv → 3.3.1.tar.gz.drv
python3.10-calver: ∅ → 2022.06.26.drv
python3.10-click: 8.1.3.drv → 8.1.6.drv
python3.10-filelock: 3.12.0.drv → 3.12.2.drv
python3.10-flit-core: 3.8.0.drv → 3.9.0.drv
python3.10-hatchling: 1.13.0.drv → 1.18.0.drv
python3.10-lxml: 4.9.2.drv → 4.9.3-3.drv
python3.10-markdown: 3.4.3.drv → 3.4.4.drv
python3.10-packaging: 23.0.drv → 23.1.drv
python3.10-pluggy: 1.0.0.drv → 1.2.0.drv
python3.10-pygments: 2.14.0.drv → 2.15.1.drv
python3.10-pytest: 7.2.1.drv → 7.4.0.drv
python3.10-pytest-asyncio: 0.20.3.drv → 0.21.1.drv
python3.10-pytest-mock: 3.10.0.drv → 3.11.1.drv
python3.10-pytest-xdist: 3.2.1.drv → 3.3.1.drv
python3.10-pyyaml: 6.0.drv → 6.0.1.drv
python3.10-trove-classifiers: ∅ → 2023.7.6.drv
python3.10-typing-extensions: 4.5.0.drv → 4.7.1.drv
python3.10-urllib3: 1.26.14.drv → 1.26.16.drv
re2c: 3.0.drv → 3.1.drv
rhash: 1.4.3.drv → 1.4.4.drv
rust: 1.69.0-x86_64-unknown-linux-gnu.tar.gz.drv → 1.70.0-x86_64-unknown-linux-gnu.tar.gz.drv
rustc: 1.70.0-src.tar.gz.drv, 1.70.0.drv → 1.71.1-src.tar.gz.drv, 1.71.1.drv
rustc-bootstrap: 1.69.0.drv → 1.70.0.drv
tar: 1.34.tar.xz.drv → 1.35.tar.xz.drv
trove-classifiers: ∅ → 2023.7.6.tar.gz.drv
typing_extensions: 4.5.0.tar.gz.drv → 4.7.1.tar.gz.drv
update-warning-regex.drv: ∅ → ε
urllib3: 1.26.14.tar.gz.drv → 1.26.16.tar.gz.drv
xgcc: +9.4 KiB
```